### PR TITLE
Option to use symmetric GPG encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ environment.
 - [ ] __CI environment variable `GCP_PASSWD`__ to be set if the key is encrypted.
 - [ ] __openssl__ is required for key decryption. This is standard on Travis. AppVeyor may require that you add some extra things to your `PATH`, but you may not have to install anything extra.
 - [ ] __gpg__ is required to verify the Janus binary. This is standard on Travis and AppVeyor.
+- [ ] __gpg__ can also be used for key decryption (with symmetric cipher). This solution is more portable than `opensl` encryption.
 - [ ] __rev__, __curl__, and a few other basic bash commands are required for the installer script. Standard on Travis, can be added to PATH for AppVeyor as per example below
 
 #### Install Janus:
@@ -102,7 +103,24 @@ replaces this:
 ## Examples and notes
 Please visit the [/examples directory](./examples) to find example Travis and AppVeyor configuration files, deploy script, and service key.
 
-#### Gotchas
+### Encrypting files
+#### With OpenSSL
+To encrypt file with `openssl` you should use following command:
+```
+openssl openssl aes-256-cbc -e -in input_file.json -out output_file.json.enc
+```
+#### With GPG
+To encrypt file with `gpg` you should use following command:
+```
+gpg --symmetric --cipher-algo AES-256 --output output_file.json.enc input_file.json
+```
+Different `--cipher-algo` may be used as well.
+
+### Gotchas
+
+The same version of `openssl` should be used for file encryption and decryption.
+
+----
 
 If you use a `script` deploy for Travis, __ensure that the deploy script is executable__, eg.
 ```yml

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 
 	// Deploy flags
 	var key, files, to string
+	var gpg bool
 	// Version flags
 	var dir, format string
 
@@ -37,6 +38,7 @@ eg.
 `)
 	deployCommand.StringVar(&files, "files", "", "file(s) to upload, allows globbing")
 	deployCommand.StringVar(&key, "key", "", "service account json key file, may be encrypted OR decrypted")
+	deployCommand.BoolVar(&gpg, "gpg", false, "use GPG 2 instead of openssl for decryption")
 	// Version
 	versionCommand.StringVar(&dir, "dir", "", `path to base directory`)
 	versionCommand.StringVar(&format, "format", "", `format of git version:
@@ -98,7 +100,7 @@ Default: v%M.%m.%P+%C-%S -> v3.5.0+66-bbb06b1
 
 		// Handle deploy.
 		// -- Will check for existing file(s) to upload, will return error if not exists.
-		if e := gcp.SendToGCP(to, files, key); e != nil {
+		if e := gcp.SendToGCP(to, files, key, gpg); e != nil {
 			fmt.Println("Failed to deploy:")
 			fmt.Println(e)
 			os.Exit(1)


### PR DESCRIPTION
`-gpg` flag instructs `janus` to use GPG instead of openssl for file
decryption. This is more secure, portable and flexible solution.

This resolves #8.